### PR TITLE
fix: change confusing "JSON" to "SQL" in sidebar 

### DIFF
--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -1,6 +1,6 @@
 [general]
 copyright = 2009-2021
-project = JSON Connector Service
+project = SQL Connector Service
 release = 2.3.1
 
 [html_theme_options]


### PR DESCRIPTION
This is a trivial one-word fix, but it is still necessary. 
See screenshot what needs to be fixed . The word "JSON connector" still appears in the sidebar of the documentation of the SQL connector.

![typo3-svg-vs-json-connector-service](https://user-images.githubusercontent.com/603200/126166239-b99d1eff-e978-4a49-9a9f-013e2a2c48f6.png)
