### PR TITLE
fix: change "ADODB" mention to "DBAL", in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "cobweb/svconnector_sql",
 	"type": "typo3-cms-extension",
-	"description": "Connector service for any SQL-based database via ADODB.",
+	"description": "Connector service for any SQL-based database via Doctrine-DBAL.",
 	"license": [
 		"GPL-2.0-or-later"
 	],


### PR DESCRIPTION
Hello again, me again, another 1-word fix.  
Description in "ext_localconf.json" is correct, IMHO:  
`'description' => 'Connector service to issue SQL query to any database, via Doctrine DBAL',`  
https://github.com/knbknb/svconnector_sql/blob/8051eca82c33d43f6224ceea959fabd9f55d9088/ext_localconf.php#L14

However: "composer.json" was not. 
`"description": "Connector service for any SQL-based database via ADODB.",`